### PR TITLE
netd: Allow devices to force-add directly-connected routes

### DIFF
--- a/server/Android.mk
+++ b/server/Android.mk
@@ -68,6 +68,10 @@ ifneq ($(TARGET_PRODUCT), gce_x86_phone)
 endif
 endif
 
+ifeq ($(strip $(TARGET_NEEDS_NETD_DIRECT_CONNECT_RULE)),true)
+        LOCAL_CPPFLAGS += -DNEEDS_NETD_DIRECT_CONNECT_RULE
+endif
+
 LOCAL_INIT_RC := netd.rc
 
 LOCAL_SHARED_LIBRARIES := \

--- a/server/RouteController.cpp
+++ b/server/RouteController.cpp
@@ -67,6 +67,9 @@ const uint32_t RULE_PRIORITY_IMPLICIT_NETWORK    = 19000;
 const uint32_t RULE_PRIORITY_BYPASSABLE_VPN      = 20000;
 const uint32_t RULE_PRIORITY_VPN_FALLTHROUGH     = 21000;
 const uint32_t RULE_PRIORITY_DEFAULT_NETWORK     = 22000;
+#ifdef NEEDS_NETD_DIRECT_CONNECT_RULE
+const uint32_t RULE_PRIORITY_DIRECTLY_CONNECTED  = 23000;
+#endif
 const uint32_t RULE_PRIORITY_UNREACHABLE         = 32000;
 
 const uint32_t ROUTE_TABLE_LOCAL_NETWORK  = 97;
@@ -697,6 +700,24 @@ int RouteController::configureDummyNetwork() {
     return 0;
 }
 
+#ifdef NEEDS_NETD_DIRECT_CONNECT_RULE
+// Add a new rule to look up the 'main' table, with the same selectors as the "default network"
+// rule, but with a lower priority. We will never create routes in the main table; it should only be
+// used for directly-connected routes implicitly created by the kernel when adding IP addresses.
+// This is necessary, for example, when adding a route through a directly-connected gateway: in
+// order to add the route, there must already be a directly-connected route that covers the gateway.
+WARN_UNUSED_RESULT int addDirectlyConnectedRule() {
+    Fwmark fwmark;
+    Fwmark mask;
+
+    fwmark.netId = NETID_UNSET;
+    mask.netId = FWMARK_NET_ID_MASK;
+
+    return modifyIpRule(RTM_NEWRULE, RULE_PRIORITY_DIRECTLY_CONNECTED, RT_TABLE_MAIN,
+                        fwmark.intValue, mask.intValue, IIF_NONE, OIF_NONE, UID_ROOT, UID_ROOT);
+}
+#endif
+
 // Add an explicit unreachable rule close to the end of the prioriy list to make it clear that
 // relying on the kernel-default "from all lookup main" rule at priority 32766 is not intended
 // behaviour. We do flush the kernel-default rules at startup, but having an explicit unreachable
@@ -955,6 +976,11 @@ int RouteController::Init(unsigned localNetId) {
     if (int ret = addLocalNetworkRules(localNetId)) {
         return ret;
     }
+#ifdef NEEDS_NETD_DIRECT_CONNECT_RULE
+    if (int ret = addDirectlyConnectedRule()) {
+        return ret;
+    }
+#endif
     if (int ret = addUnreachableRule()) {
         return ret;
     }


### PR DESCRIPTION
Most sane devices have directly-connected routes properly
added by ConnectivityService, but a number of Samsung RIL
libraries seem to be doing "special" things, the end result
of which is IPv4 mobile data is non-functional due to lack
of a default route.

Affected devices have a log entry similar to the below:
  Error adding route 0.0.0.0/0 -> xxx.xxx.xxx.xxx rmnet0 to table 1002: Network is unreachable

This reverts, with guards, commit 92e8f96e43320efd5183d7452fb90883fd96415e.

Change-Id: I6a653d19c1c72c136e78d8d841e87d3c166698ea